### PR TITLE
3D potential functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,8 +299,18 @@ endif(PRISMATIC_ENABLE_PYPRISMATIC)
 
 if (PRISMATIC_TESTS)
     find_package (Boost REQUIRED COMPONENTS unit_test_framework)
-    add_executable(prismatic-tests
-                    ${TEST_SOURCE_FILES})
+
+    if (PRISMATIC_ENABLE_GPU)
+        cuda_add_executable(prismatic-tests
+                        ${SOURCE_FILES}
+                        ${CUDA_SOURCE_FILES}
+                        ${TEST_SOURCE_FILES})
+        cuda_add_cufft_to_target(prismatic-tests)
+    else(PRISMATIC_ENABLE_GPU)
+        add_executable(prismatic-tests
+                        ${SOURCE_FILES}
+                        ${TEST_SOURCE_FILES})
+    endif (PRISMATIC_ENABLE_GPU)
 
     target_compile_definitions(prismatic-tests PRIVATE "BOOST_TEST_DYN_LINK=1")
 
@@ -312,4 +322,5 @@ if (PRISMATIC_TESTS)
 
     add_custom_target(PrismaticTestSuite ALL ./prismatic-tests
                         DEPENDS prismatic prismatic-tests)
+
 endif (PRISMATIC_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ if (PRISMATIC_TESTS)
         ${HDF5_LIBRARIES}
         ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
-    add_custom_target(PrismaticTestSuite ALL ./prismatic-tests
+    add_custom_target(PrismaticTestSuite ALL ./prismatic-tests --log_level=all
                         DEPENDS prismatic prismatic-tests)
 
 endif (PRISMATIC_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,9 @@ endif (PRISMATIC_ENABLE_GPU)
 
 if (PRISMATIC_TESTS)
     set(TEST_SOURCE_FILES
-            unittests/testSuite.cpp)
+            unittests/testSuite.cpp
+            unittests/potentialTests.cpp
+            )
 endif (PRISMATIC_TESTS)
 
 # find core packages
@@ -99,6 +101,7 @@ set(HDF5_LIBRARIES ${HDF5_C_HL_LIBRARIES} ${HDF5_C_LIBRARIES} ${HDF5_CXX_HL_LIBR
 
 message("Boost dir " ${Boost_INCLUDE_DIRS})
 include_directories(${CMAKE_SOURCE_DIR}/include
+                    ${CMAKE_SOURCE_DIR}/unittests/include
                     ${Boost_INCLUDE_DIRS}
                     ${FFTW_INCLUDE_DIR}
                     ${HDF5_INCLUDE_DIRS})
@@ -295,11 +298,18 @@ if(PRISMATIC_ENABLE_PYPRISMATIC)
 endif(PRISMATIC_ENABLE_PYPRISMATIC)
 
 if (PRISMATIC_TESTS)
+    find_package (Boost REQUIRED COMPONENTS unit_test_framework)
     add_executable(prismatic-tests
                     ${TEST_SOURCE_FILES})
+
+    target_compile_definitions(prismatic-tests PRIVATE "BOOST_TEST_DYN_LINK=1")
+
     target_link_libraries(prismatic-tests
         ${CMAKE_THREAD_LIBS_INIT}
         ${FFTW_LIBRARIES}
-        ${HDF5_LIBRARIES})
+        ${HDF5_LIBRARIES}
+        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
+    add_custom_target(PrismaticTestSuite ALL ./prismatic-tests
+                        DEPENDS prismatic prismatic-tests)
 endif (PRISMATIC_TESTS)

--- a/include/ArrayND.h
+++ b/include/ArrayND.h
@@ -436,6 +436,32 @@ std::pair<Array2D_T<T>, Array2D_T<T>> meshgrid(const Array1D_T<T> &Y, const Arra
 	return std::pair<Array2D_T<T>, Array2D_T<T>>(yy, xx);
 }
 
+template <class T>
+using Array3D_T = Prismatic::ArrayND<3, std::vector<T>>;
+template <class T>
+using Array1D_T = Prismatic::ArrayND<1, std::vector<T>>;
+template <class T>
+std::tuple<Array3D_T<T>, Array3D_T<T>, Array3D_T<T>> meshgrid(const Array1D_T<T> &Z, const Array1D_T<T> &Y, const Array1D_T<T> &X)
+{
+	Array3D_T<T> zz = zeros_ND<3, T>({{Z.size(), Y.size(), X.size()}});
+	Array3D_T<T> yy = zeros_ND<3, T>({{Z.size(), Y.size(), X.size()}});
+	Array3D_T<T> xx = zeros_ND<3, T>({{Z.size(), Y.size(), X.size()}});
+	for (auto k = 0; k < xx.get_dimk(); k++)
+	{
+		for (auto j = 0; j < xx.get_dimj(); ++j)
+		{
+			for (auto i = 0; i < xx.get_dimi(); ++i)
+			{
+				zz.at(k, j, i) = Z[k];
+				yy.at(k, j, i) = Y[j];
+				xx.at(k, j, i) = X[i];
+			}
+		}
+	}
+
+	return std::tuple<Array3D_T<T>, Array3D_T<T>, Array3D_T<T>>(zz, yy, xx);
+}
+
 template <>
 inline void ArrayND<3, std::vector<double>>::toMRC_f(const char *filename) const
 {

--- a/include/PRISM01_calcPotential.h
+++ b/include/PRISM01_calcPotential.h
@@ -43,6 +43,18 @@ void generateProjectedPotentials(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 								 const Array1D<long> &yvec,
 								 const Array1D<PRISMATIC_FLOAT_PRECISION> &uLookup);
 
+void interpolatePotential(Array3D<PRISMATIC_FLOAT_PRECISION> &potShift,
+							const Array3D<PRISMATIC_FLOAT_PRECISION> &potCrop,
+							const PRISMATIC_FLOAT_PRECISION &wx,
+							const PRISMATIC_FLOAT_PRECISION &wy,
+							const PRISMATIC_FLOAT_PRECISION &wz,
+							const size_t &xind,
+							const size_t &yind,
+							const size_t &zind);
+
+void generateProjectedPotentials3D(Array3D<PRISMATIC_FLOAT_PRECISION> &pot,
+								   const Array3D<PRISMATIC_FLOAT_PRECISION> &potLookup);
+
 //#ifdef PRISMATIC_BUILDING_GUI
 //	void PRISM01_calcPotential(Parameters<PRISMATIC_FLOAT_PRECISION>& pars, prism_progressbar *progressbar=NULL);
 //#else

--- a/include/PRISM01_calcPotential.h
+++ b/include/PRISM01_calcPotential.h
@@ -43,6 +43,8 @@ void generateProjectedPotentials(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 								 const Array1D<long> &yvec,
 								 const Array1D<PRISMATIC_FLOAT_PRECISION> &uLookup);
 
+PRISMATIC_FLOAT_PRECISION kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> factors, PRISMATIC_FLOAT_PRECISION radius);
+
 //#ifdef PRISMATIC_BUILDING_GUI
 //	void PRISM01_calcPotential(Parameters<PRISMATIC_FLOAT_PRECISION>& pars, prism_progressbar *progressbar=NULL);
 //#else

--- a/include/PRISM01_calcPotential.h
+++ b/include/PRISM01_calcPotential.h
@@ -43,7 +43,7 @@ void generateProjectedPotentials(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 								 const Array1D<long> &yvec,
 								 const Array1D<PRISMATIC_FLOAT_PRECISION> &uLookup);
 
-PRISMATIC_FLOAT_PRECISION kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> factors, PRISMATIC_FLOAT_PRECISION radius);
+Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> &factors, Array3D<PRISMATIC_FLOAT_PRECISION> &radius);
 
 //#ifdef PRISMATIC_BUILDING_GUI
 //	void PRISM01_calcPotential(Parameters<PRISMATIC_FLOAT_PRECISION>& pars, prism_progressbar *progressbar=NULL);

--- a/include/PRISM01_calcPotential.h
+++ b/include/PRISM01_calcPotential.h
@@ -43,8 +43,6 @@ void generateProjectedPotentials(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 								 const Array1D<long> &yvec,
 								 const Array1D<PRISMATIC_FLOAT_PRECISION> &uLookup);
 
-Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> &factors, Array3D<PRISMATIC_FLOAT_PRECISION> &radius);
-
 //#ifdef PRISMATIC_BUILDING_GUI
 //	void PRISM01_calcPotential(Parameters<PRISMATIC_FLOAT_PRECISION>& pars, prism_progressbar *progressbar=NULL);
 //#else

--- a/include/PRISM01_calcPotential.h
+++ b/include/PRISM01_calcPotential.h
@@ -34,6 +34,12 @@ void fetch_potentials(Array3D<PRISMATIC_FLOAT_PRECISION> &potentials,
 					  const Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
 					  const Array1D<PRISMATIC_FLOAT_PRECISION> &yr);
 
+void fetch_potentials3D(Array4D<PRISMATIC_FLOAT_PRECISION> &potentials,
+					  const std::vector<size_t> &atomic_species,
+					  const Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
+					  const Array1D<PRISMATIC_FLOAT_PRECISION> &yr,
+					  const Array1D<PRISMATIC_FLOAT_PRECISION> &zr);
+
 std::vector<size_t> get_unique_atomic_species(Parameters<PRISMATIC_FLOAT_PRECISION> &pars);
 
 void generateProjectedPotentials(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
@@ -53,10 +59,12 @@ void interpolatePotential(Array3D<PRISMATIC_FLOAT_PRECISION> &potShift,
 							const size_t &zind);
 
 void cropLookup(Array3D<PRISMATIC_FLOAT_PRECISION> &potCrop,
-				const Array3D<PRISMATIC_FLOAT_PRECISION> &potLookup);
+				const Array4D<PRISMATIC_FLOAT_PRECISION> &potLookup,
+				const size_t &cur_Z);
 
 void generateProjectedPotentials3D(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
-								   const Array3D<PRISMATIC_FLOAT_PRECISION> &potLookup,
+								   const Array4D<PRISMATIC_FLOAT_PRECISION> &potLookup,
+								   const std::vector<size_t> &unique_species,
 								   const Array1D<long> &xvec,
 								   const Array1D<long> &yvec,
 								   const Array1D<long> &zvec);

--- a/include/PRISM01_calcPotential.h
+++ b/include/PRISM01_calcPotential.h
@@ -52,8 +52,14 @@ void interpolatePotential(Array3D<PRISMATIC_FLOAT_PRECISION> &potShift,
 							const size_t &yind,
 							const size_t &zind);
 
-void generateProjectedPotentials3D(Array3D<PRISMATIC_FLOAT_PRECISION> &pot,
-								   const Array3D<PRISMATIC_FLOAT_PRECISION> &potLookup);
+void cropLookup(Array3D<PRISMATIC_FLOAT_PRECISION> &potCrop,
+				const Array3D<PRISMATIC_FLOAT_PRECISION> &potLookup);
+
+void generateProjectedPotentials3D(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
+								   const Array3D<PRISMATIC_FLOAT_PRECISION> &potLookup,
+								   const Array1D<long> &xvec,
+								   const Array1D<long> &yvec,
+								   const Array1D<long> &zvec);
 
 //#ifdef PRISMATIC_BUILDING_GUI
 //	void PRISM01_calcPotential(Parameters<PRISMATIC_FLOAT_PRECISION>& pars, prism_progressbar *progressbar=NULL);

--- a/include/meta.h
+++ b/include/meta.h
@@ -78,6 +78,7 @@ namespace Prismatic{
             randomSeed            = rand() % 100000;
             crop4Damax            = 100.0 /1000;
             algorithm             = Algorithm::PRISM;
+            potential3D           = true;
             includeThermalEffects = true;
             includeOccupancy      = true;
             alsoDoCPUWork         = true;
@@ -141,6 +142,7 @@ namespace Prismatic{
         size_t numGPUs; // number of GPUs to use
         size_t numStreamsPerGPU; // number of CUDA streams to use per GPU
         Algorithm algorithm;
+        bool potential3D;
         bool includeThermalEffects;
         bool includeOccupancy;
         bool alsoDoCPUWork; // what fraction of computation to do on the cpu vs gpu

--- a/include/meta.h
+++ b/include/meta.h
@@ -40,6 +40,7 @@ namespace Prismatic{
             numFP                 = 1;
             fpNum                 = 1;
             sliceThickness        = 2.0;
+            zSampling             = 4;
             numSlices             = 0; 
             zStart                = 0.0;
             cellDim               = std::vector<T>{20.0, 20.0, 20.0}; // this is z,y,x format
@@ -105,6 +106,7 @@ namespace Prismatic{
         size_t numFP; // number of frozen phonon configurations to compute
         size_t fpNum; // current frozen phonon number
         T sliceThickness; // thickness of slice in Z
+        size_t zSampling; //oversampling of potential in Z direction
         size_t numSlices; //number of slices to itereate through in multislice before giving an output
         T zStart; //Z coordinate of cell where multislice intermediate output will begin outputting
         T probeStepX;

--- a/include/params.h
+++ b/include/params.h
@@ -85,6 +85,7 @@ namespace Prismatic{
 	    std::vector<atom> atoms;
 	    std::vector<T> pixelSize;
 	    std::vector<T> pixelSizeOutput;
+		T dzPot;
 	    Array1D<size_t> imageSize;
 	    std::vector<size_t> imageSizeReduce;
 	    Array1D<size_t> imageSizeOutput;
@@ -110,23 +111,23 @@ namespace Prismatic{
 		H5::H5File outputFile;
 		size_t fpFlag; //flag to prevent creation of new HDF5 files
 
-#ifdef PRISMATIC_ENABLE_GPU
-		cudaDeviceProp deviceProperties;
-//#ifndef NDEBUG
-		// for monitoring memory consumption on GPU
-	    size_t maxGPUMem;
-	    size_t targetNumBlocks; // estimate for a good number of blocks to launch on GPU so that enough are made to fill the device without incurring too much overhead unnecessarily
-//#endif //NDEBUG
-#endif // PRISMATIC_ENABLE_GPU
-#ifdef PRISMATIC_BUILDING_GUI
-	    prism_progressbar *progressbar;
-#endif
+		#ifdef PRISMATIC_ENABLE_GPU
+				cudaDeviceProp deviceProperties;
+		//#ifndef NDEBUG
+				// for monitoring memory consumption on GPU
+				size_t maxGPUMem;
+				size_t targetNumBlocks; // estimate for a good number of blocks to launch on GPU so that enough are made to fill the device without incurring too much overhead unnecessarily
+		//#endif //NDEBUG
+		#endif // PRISMATIC_ENABLE_GPU
+		#ifdef PRISMATIC_BUILDING_GUI
+				prism_progressbar *progressbar;
+		#endif
 		Parameters(){};
-#ifdef PRISMATIC_BUILDING_GUI
-	    Parameters(Metadata<T> _meta, prism_progressbar* _progressbar = NULL) : meta(_meta), progressbar(_progressbar){
-#else
+		#ifdef PRISMATIC_BUILDING_GUI
+		Parameters(Metadata<T> _meta, prism_progressbar* _progressbar = NULL) : meta(_meta), progressbar(_progressbar){
+		#else
 	    Parameters(Metadata<T> _meta) : meta(_meta){
-#endif
+		#endif
 
 		    constexpr double m = 9.109383e-31;
 		    constexpr double e = 1.602177e-19;

--- a/include/projectedPotential.h
+++ b/include/projectedPotential.h
@@ -27,6 +27,11 @@ namespace Prismatic {
                                      const Array1D<PRISMATIC_FLOAT_PRECISION>& xr,
                                      const Array1D<PRISMATIC_FLOAT_PRECISION>& yr);
 
+	PRISMATIC_FLOAT_PRECISION get_potMin3D(const Array3D<PRISMATIC_FLOAT_PRECISION>& pot,
+                                     const Array1D<PRISMATIC_FLOAT_PRECISION>& xr,
+                                     const Array1D<PRISMATIC_FLOAT_PRECISION>& yr,
+                                     const Array1D<PRISMATIC_FLOAT_PRECISION>& zr);
+
 	Array2D<PRISMATIC_FLOAT_PRECISION> projPot(const size_t &Z,
 	                                       const Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
 	                                       const Array1D<PRISMATIC_FLOAT_PRECISION> &yr);

--- a/include/projectedPotential.h
+++ b/include/projectedPotential.h
@@ -37,9 +37,9 @@ namespace Prismatic {
 	                                       const Array1D<PRISMATIC_FLOAT_PRECISION> &yr);
 
 	Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(const size_t &Z,
-														Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
-														Array1D<PRISMATIC_FLOAT_PRECISION> &yr,
-														Array1D<PRISMATIC_FLOAT_PRECISION> &zr);
+														const Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
+														const Array1D<PRISMATIC_FLOAT_PRECISION> &yr,
+														const Array1D<PRISMATIC_FLOAT_PRECISION> &zr);
 
 }
 #endif //PRISM_PROJPOT_H

--- a/include/projectedPotential.h
+++ b/include/projectedPotential.h
@@ -31,5 +31,8 @@ namespace Prismatic {
 	                                       const Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
 	                                       const Array1D<PRISMATIC_FLOAT_PRECISION> &yr);
 
+	Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> &factors,
+														Array3D<PRISMATIC_FLOAT_PRECISION> &radius);
+
 }
 #endif //PRISM_PROJPOT_H

--- a/include/projectedPotential.h
+++ b/include/projectedPotential.h
@@ -31,8 +31,10 @@ namespace Prismatic {
 	                                       const Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
 	                                       const Array1D<PRISMATIC_FLOAT_PRECISION> &yr);
 
-	Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> &factors,
-														Array3D<PRISMATIC_FLOAT_PRECISION> &radius);
+	Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(const size_t &Z,
+														Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
+														Array1D<PRISMATIC_FLOAT_PRECISION> &yr,
+														Array1D<PRISMATIC_FLOAT_PRECISION> &zr);
 
 }
 #endif //PRISM_PROJPOT_H

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -33,27 +33,7 @@
 
 namespace Prismatic
 {
-static const PRISMATIC_FLOAT_PRECISION pi = acos(-1);
 using namespace std;
-
-Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> &factors, Array3D<PRISMATIC_FLOAT_PRECISION> &radius){
-	PRISMATIC_FLOAT_PRECISION a0 = 0.529; //bohr radius
-	PRISMATIC_FLOAT_PRECISION e = 14.4; //electron charge in Volt-Angstoms
-	Array3D<PRISMATIC_FLOAT_PRECISION> cur_pot = zeros_ND<3,PRISMATIC_FLOAT_PRECISION>({{radius.get_dimk(),radius.get_dimj(),radius.get_dimi()}});
-	for(auto z = 0; z < radius.get_dimk(); z++){
-        for(auto y = 0; y < radius.get_dimj(); y++ ){
-            for(auto x = 0; x < radius.get_dimi(); x++){
-				for(auto i = 0; i<6; i+=2){
-					cur_pot.at(z,y,x) += 2*pi*pi*a0*e*(factors.at(i)/radius.at(z,y,x))*exp(-2*pi*radius.at(z,y,x)*sqrt(factors.at(i+1)));
-				}
-				for(auto i = 6; i<12; i+=2){
-					cur_pot.at(z,y,x) += 2*pow(pi,5.0/2.0)*a0*e*factors.at(i)*pow(factors.at(i+1),-3.0/2.0)*exp(-pi*pi*radius.at(z,y,x)*radius.at(z,y,x)/factors.at(i+1));
-				}
-            }
-        }
-    }
-	return cur_pot;
-}
 
 void fetch_potentials(Array3D<PRISMATIC_FLOAT_PRECISION> &potentials,
 					  const vector<size_t> &atomic_species,

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -287,6 +287,9 @@ void generateProjectedPotentials3D(Parameters<PRISMATIC_FLOAT_PRECISION> &pars,
 								   const Array1D<long> &zvec)
 {		
 	long numPlanes = round(pars.tiledCellDim[0]/pars.meta.sliceThickness);
+	//check if intermediate output was specified, if so, create index of output slices
+	if (pars.meta.numSlices == 0) pars.numSlices = pars.numPlanes;
+
 	pars.pot = zeros_ND<3,PRISMATIC_FLOAT_PRECISION>({{numPlanes, pars.imageSize[0], pars.imageSize[1]}});
 	Array3D<PRISMATIC_FLOAT_PRECISION> potFull = zeros_ND<3,PRISMATIC_FLOAT_PRECISION>({{numPlanes*pars.meta.zSampling, pars.imageSize[1], pars.imageSize[0]}});
 

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -33,11 +33,26 @@
 
 namespace Prismatic
 {
+static const PRISMATIC_FLOAT_PRECISION pi = acos(-1);
 using namespace std;
 
-PRISMATIC_FLOAT_PRECISION kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> , PRISMATIC_FLOAT_PRECISION radius){
-	PRISMATIC_FLOAT_PRECISION val = 1.0;
-	return val;
+Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> &factors, Array3D<PRISMATIC_FLOAT_PRECISION> &radius){
+	PRISMATIC_FLOAT_PRECISION a0 = 0.529; //bohr radius
+	PRISMATIC_FLOAT_PRECISION e = 14.4; //electron charge in Volt-Angstoms
+	Array3D<PRISMATIC_FLOAT_PRECISION> cur_pot = zeros_ND<3,PRISMATIC_FLOAT_PRECISION>({{radius.get_dimk(),radius.get_dimj(),radius.get_dimi()}});
+	for(auto z = 0; z < radius.get_dimk(); z++){
+        for(auto y = 0; y < radius.get_dimj(); y++ ){
+            for(auto x = 0; x < radius.get_dimi(); x++){
+				for(auto i = 0; i<6; i+=2){
+					cur_pot.at(z,y,x) += 2*pi*pi*a0*e*(factors.at(i)/radius.at(z,y,x))*exp(-2*pi*radius.at(z,y,x)*sqrt(factors.at(i+1)));
+				}
+				for(auto i = 6; i<12; i+=2){
+					cur_pot.at(z,y,x) += 2*pow(pi,5.0/2.0)*a0*e*factors.at(i)*pow(factors.at(i+1),-3.0/2.0)*exp(-pi*pi*radius.at(z,y,x)*radius.at(z,y,x)/factors.at(i+1));
+				}
+            }
+        }
+    }
+	return cur_pot;
 }
 
 void fetch_potentials(Array3D<PRISMATIC_FLOAT_PRECISION> &potentials,

--- a/src/PRISM01_calcPotential.cpp
+++ b/src/PRISM01_calcPotential.cpp
@@ -34,6 +34,12 @@
 namespace Prismatic
 {
 using namespace std;
+
+PRISMATIC_FLOAT_PRECISION kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> , PRISMATIC_FLOAT_PRECISION radius){
+	PRISMATIC_FLOAT_PRECISION val = 1.0;
+	return val;
+}
+
 void fetch_potentials(Array3D<PRISMATIC_FLOAT_PRECISION> &potentials,
 					  const vector<size_t> &atomic_species,
 					  const Array1D<PRISMATIC_FLOAT_PRECISION> &xr,

--- a/src/parseInput.cpp
+++ b/src/parseInput.cpp
@@ -87,6 +87,7 @@ void printHelp()
               << "* --num-FP (-F) value : number of frozen phonon configurations to calculate (default: " << defaults.numFP << ")\n"
               << "* --thermal-effects (-te) bool : whether or not to include Debye-Waller factors (thermal effects) (default: True)\n"
               << "* --occupancy (-oc) bool : whether or not to consider occupancy values for likelihood of atoms existing at each site (default: True)\n"
+              << "* --3Dpotential (-3DP) bool : whether or not to use 3D parameterization with subpixel shifting for calculating the atomic potentials (default: True)\n"
               << "* --save-2D-output (-2D) ang_min ang_max : save the 2D STEM image integrated between ang_min and ang_max (in mrads) (default: Off)\n"
               << "* --save-3D-output (-3D) bool=true : Also save the 3D output at the detector for each probe (3D output mode) (default: On)\n"
               << "* --save-4D-output (-4D) bool=false : Also save the 4D output at the detector for each probe (4D output mode) (default: Off)\n"
@@ -1260,6 +1261,20 @@ bool parse_oc(Metadata<PRISMATIC_FLOAT_PRECISION> &meta,
     return true;
 };
 
+bool parse_3DP(Metadata<PRISMATIC_FLOAT_PRECISION> &meta,
+              int &argc, const char ***argv)
+{
+    if (argc < 2)
+    {
+        cout << "No value provided for -3DP (syntax is -3DP bool)\n";
+        return false;
+    }
+    meta.potential3D = std::string((*argv)[1]) == "0" ? false : true;
+    argc -= 2;
+    argv[0] += 2;
+    return true;
+};
+
 bool parse_2D(Metadata<PRISMATIC_FLOAT_PRECISION> &meta,
               int &argc, const char ***argv)
 {
@@ -1464,6 +1479,7 @@ static std::map<std::string, parseFunction> parser{
     {"--num-FP", parse_F}, {"-F", parse_F},
     {"--thermal-effects", parse_te}, {"-te", parse_te},
     {"--occupancy", parse_oc}, {"-oc", parse_oc},
+    {"--3Dpotential", parse_3DP}, {"-3DP", parse_3DP},
     {"--save-2D-output", parse_2D}, {"-2D", parse_2D},
     {"--save-3D-output", parse_3D}, {"-3D", parse_3D},
     {"--save-4D-output", parse_4D}, {"-4D", parse_4D},

--- a/src/projectedPotential.cpp
+++ b/src/projectedPotential.cpp
@@ -30,19 +30,45 @@ PRISMATIC_FLOAT_PRECISION get_potMin(const Array2D<PRISMATIC_FLOAT_PRECISION> &p
 									 const Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
 									 const Array1D<PRISMATIC_FLOAT_PRECISION> &yr)
 {
-	// I am assuming that xr and yr are symmetric about 0
+	//xr and yr are generated symmetric about 0
+	//TODO: decide to bifurcate into legacy functionality?
+
 	const size_t xInd = std::floor(xr.size() / 2);
 	const size_t yInd = std::floor(yr.size() / 2);
-	const PRISMATIC_FLOAT_PRECISION dx = round(sqrt(2 * (xInd + 1) - 1));
-	const PRISMATIC_FLOAT_PRECISION dy = round(sqrt(2 * (yInd + 1) - 1));
-	const PRISMATIC_FLOAT_PRECISION xv[] = {xInd - dx, xInd + dx, xInd - dx, xInd + dx, 0, 0, (PRISMATIC_FLOAT_PRECISION)xr.size() - 1, (PRISMATIC_FLOAT_PRECISION)xr.size() - 1};
-	const PRISMATIC_FLOAT_PRECISION yv[] = {0, 0, (PRISMATIC_FLOAT_PRECISION)yr.size() - 1, (PRISMATIC_FLOAT_PRECISION)yr.size() - 1, yInd - dy, yInd + dy, yInd - dy, yInd + dy};
+	// const PRISMATIC_FLOAT_PRECISION dx = round(sqrt(2 * (xInd + 1) - 1));
+	// const PRISMATIC_FLOAT_PRECISION dy = round(sqrt(2 * (yInd + 1) - 1));
+	// const PRISMATIC_FLOAT_PRECISION xv[] = {xInd - dx, xInd + dx, xInd - dx, xInd + dx, 0, 0, (PRISMATIC_FLOAT_PRECISION)xr.size() - 1, (PRISMATIC_FLOAT_PRECISION)xr.size() - 1};
+	// const PRISMATIC_FLOAT_PRECISION yv[] = {0, 0, (PRISMATIC_FLOAT_PRECISION)yr.size() - 1, (PRISMATIC_FLOAT_PRECISION)yr.size() - 1, yInd - dy, yInd + dy, yInd - dy, yInd + dy};
+
+	const PRISMATIC_FLOAT_PRECISION xv[] = {(PRISMATIC_FLOAT_PRECISION)xr.size() - 2, xInd}; //-2 to gaurantee zero faces
+	const PRISMATIC_FLOAT_PRECISION yv[] = {yInd, (PRISMATIC_FLOAT_PRECISION)yr.size() - 2};
 
 	PRISMATIC_FLOAT_PRECISION potMin = 0;
-	for (auto i = 0; i < 8; ++i)
+	for (auto i = 0; i < 2; ++i)
 		potMin = (pot.at(yv[i], xv[i]) > potMin) ? pot.at(yv[i], xv[i]) : potMin;
 	return potMin;
 }
+
+PRISMATIC_FLOAT_PRECISION get_potMin3D(const Array3D<PRISMATIC_FLOAT_PRECISION>& pot,
+                                     const Array1D<PRISMATIC_FLOAT_PRECISION>& xr,
+                                     const Array1D<PRISMATIC_FLOAT_PRECISION>& yr,
+                                     const Array1D<PRISMATIC_FLOAT_PRECISION>& zr)
+{	
+	//xr, yr, and zr are generated symmetric about zero
+	//looks for minimum potential to prevent interaction with vacuum edge at boundaries of potential integration
+	const size_t xInd = std::floor(xr.size() / 2);
+	const size_t yInd = std::floor(yr.size() / 2);
+	const size_t zInd = std::floor(zr.size() / 2);
+
+	const PRISMATIC_FLOAT_PRECISION xv[] = {(PRISMATIC_FLOAT_PRECISION)xr.size() - 2, xInd, xInd}; // -2 to guarantee zero on face
+	const PRISMATIC_FLOAT_PRECISION yv[] = {yInd, (PRISMATIC_FLOAT_PRECISION)yr.size() - 2, yInd};
+	const PRISMATIC_FLOAT_PRECISION zv[] = {zInd, zInd, (PRISMATIC_FLOAT_PRECISION)zr.size() - 2};
+
+	PRISMATIC_FLOAT_PRECISION potMin = 0;
+	for (auto i = 0; i < 3; ++i)
+		potMin = (pot.at(zv[i], yv[i], xv[i]) > potMin) ? pot.at(zv[i], yv[i], xv[i]) : potMin;
+	return potMin;
+};
 
 using namespace std;
 
@@ -188,11 +214,68 @@ Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(const size_t &Z,
 		ap[i] = fparams[(Z - 1) * NUM_PARAMETERS + i];
 	}
 
-	//construct arrays
-	std::tuple<Array3D<PRISMATIC_FLOAT_PRECISION>, Array3D<PRISMATIC_FLOAT_PRECISION>, Array3D<PRISMATIC_FLOAT_PRECISION>> meshxyz = meshgrid(zr, yr, xr);
-	Array3D<PRISMATIC_FLOAT_PRECISION> r2 = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{zr.size(), yr.size(), xr.size()}});
-	Array3D<PRISMATIC_FLOAT_PRECISION> r  = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{zr.size(), yr.size(), xr.size()}});
+	//construct arrays with supersampling
+	PRISMATIC_FLOAT_PRECISION ss = 8;
+	const PRISMATIC_FLOAT_PRECISION dx = xr[1] - xr[0];
+	const PRISMATIC_FLOAT_PRECISION dy = yr[1] - yr[0];
+	const PRISMATIC_FLOAT_PRECISION dz = zr[1] - zr[0];
 
+	PRISMATIC_FLOAT_PRECISION start = -(ss - 1) / ss / 2;
+	const PRISMATIC_FLOAT_PRECISION step = 1 / ss;
+	const PRISMATIC_FLOAT_PRECISION end = -start;
+	vector<PRISMATIC_FLOAT_PRECISION> sub_data;
+	while (start <= end)
+	{
+		sub_data.push_back(start);
+		start += step;
+	}
+	ArrayND<1, std::vector<PRISMATIC_FLOAT_PRECISION>> sub(sub_data, {{sub_data.size()}});
+
+	std::pair<Array2D<PRISMATIC_FLOAT_PRECISION>, Array2D<PRISMATIC_FLOAT_PRECISION>> meshx = meshgrid(xr, sub * dx);
+	std::pair<Array2D<PRISMATIC_FLOAT_PRECISION>, Array2D<PRISMATIC_FLOAT_PRECISION>> meshy = meshgrid(yr, sub * dy);
+	std::pair<Array2D<PRISMATIC_FLOAT_PRECISION>, Array2D<PRISMATIC_FLOAT_PRECISION>> meshz = meshgrid(zr, sub * dz);
+
+	ArrayND<1, std::vector<PRISMATIC_FLOAT_PRECISION>> xv = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{meshx.first.size()}});
+	ArrayND<1, std::vector<PRISMATIC_FLOAT_PRECISION>> yv = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{meshy.first.size()}});
+	ArrayND<1, std::vector<PRISMATIC_FLOAT_PRECISION>> zv = zeros_ND<1, PRISMATIC_FLOAT_PRECISION>({{meshz.first.size()}});
+	{
+		auto t_x = xv.begin();
+		for (auto j = 0; j < meshx.first.get_dimj(); ++j)
+		{
+			for (auto i = 0; i < meshx.first.get_dimi(); ++i)
+			{
+				*t_x++ = meshx.first.at(j, i) + meshx.second.at(j, i);
+			}
+		}
+	}
+
+	{
+		auto t_y = yv.begin();
+		for (auto j = 0; j < meshy.first.get_dimj(); ++j)
+		{
+			for (auto i = 0; i < meshy.first.get_dimi(); ++i)
+			{
+				*t_y++ = meshy.first.at(j, i) + meshy.second.at(j, i);
+			}
+		}
+	}
+
+	{
+		auto t_z = zv.begin();
+		for (auto j = 0; j < meshz.first.get_dimj(); ++j)
+		{
+			for (auto i = 0; i < meshz.first.get_dimi(); ++i)
+			{
+				*t_z++ = meshz.first.at(j, i) + meshz.second.at(j, i);
+			}
+		}
+	}
+
+	std::tuple<Array3D<PRISMATIC_FLOAT_PRECISION>, Array3D<PRISMATIC_FLOAT_PRECISION>, Array3D<PRISMATIC_FLOAT_PRECISION>> meshxyz = meshgrid(zv, yv, xv);
+	Array3D<PRISMATIC_FLOAT_PRECISION> r2 = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{zv.size(), yv.size(), xv.size()}});
+	Array3D<PRISMATIC_FLOAT_PRECISION> r  = zeros_ND<3, PRISMATIC_FLOAT_PRECISION>({{zv.size(), yv.size(), xv.size()}});
+
+	//calculate radius
 	{
 		auto t_y = r2.begin();
 		for (auto k = 0; k < std::get<0>(meshxyz).get_dimk(); k++)
@@ -211,10 +294,9 @@ Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(const size_t &Z,
 
 	for (auto i = 0; i < r.size(); ++i) r[i] = sqrt(r2[i]);
 	
+	Array3D<PRISMATIC_FLOAT_PRECISION> potSS = zeros_ND<3,PRISMATIC_FLOAT_PRECISION>({{r2.get_dimk(), r2.get_dimj(), r2.get_dimi()}});
 
-	Array3D<PRISMATIC_FLOAT_PRECISION> cur_pot = zeros_ND<3,PRISMATIC_FLOAT_PRECISION>({{r2.get_dimk(), r2.get_dimj(), r2.get_dimi()}});
-
-	std::transform(r2.begin(),r2.end(),r.begin(),cur_pot.begin(),[&ap,&term1,&term2](const PRISMATIC_FLOAT_PRECISION &r2, const PRISMATIC_FLOAT_PRECISION &r){
+	std::transform(r2.begin(),r2.end(),r.begin(),potSS.begin(),[&ap,&term1,&term2](const PRISMATIC_FLOAT_PRECISION &r2, const PRISMATIC_FLOAT_PRECISION &r){
 		return term1*(ap[0]*exp(-2*pi*r*sqrt(ap[1]))/r
 						+ ap[2]*exp(-2*pi*r*sqrt(ap[3]))/r
 						+ ap[4]*exp(-2*pi*r*sqrt(ap[5]))/r)
@@ -222,7 +304,35 @@ Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(const size_t &Z,
 					+ ap[8]*pow(ap[9],-3.0/2.0)*exp(-pi*pi*r2/ap[9])
 					+ ap[10]*pow(ap[11],-3.0/2.0)*exp(-pi*pi*r2/ap[11]));
 	});
-	return cur_pot;
+
+	//integrate
+	Array3D<PRISMATIC_FLOAT_PRECISION> pot = zeros_ND<3,PRISMATIC_FLOAT_PRECISION>({{zr.size(), yr.size(), xr.size()}});
+	for (auto sz = 0; sz < ss; ++sz)
+	{
+		for (auto sy = 0; sy < ss; ++sy)
+		{
+			for (auto sx = 0; sx < ss; ++sx)
+			{
+				for (auto k = 0; k < pot.get_dimk(); ++k)
+				{
+					for (auto j = 0; j < pot.get_dimj(); ++j)
+					{
+						for (auto i = 0; i < pot.get_dimi(); ++i)
+						{
+							pot.at(k, j, i) += potSS.at(k * ss + sz, j * ss + sy, i * ss + sx);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	pot /= ss*ss*ss;
+	PRISMATIC_FLOAT_PRECISION potMin = get_potMin3D(pot, xr, yr, zr);
+	pot -= potMin;
+	//keep potential if it is positive, else, zero
+	std::transform(pot.begin(), pot.end(), pot.begin(), [](PRISMATIC_FLOAT_PRECISION &pot){ return pot < 0 ? 0 : pot;});
+	return pot;
 }
 
 } // namespace Prismatic

--- a/src/projectedPotential.cpp
+++ b/src/projectedPotential.cpp
@@ -169,4 +169,26 @@ Array2D<PRISMATIC_FLOAT_PRECISION> projPot(const size_t &Z,
 
 	return pot;
 }
+
+Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(Array1D<PRISMATIC_FLOAT_PRECISION> &factors, Array3D<PRISMATIC_FLOAT_PRECISION> &radius){
+	PRISMATIC_FLOAT_PRECISION a0 = 0.529; //bohr radius
+	PRISMATIC_FLOAT_PRECISION e = 14.4; //electron charge in Volt-Angstoms
+	static const PRISMATIC_FLOAT_PRECISION pi = std::acos(-1);
+
+	Array3D<PRISMATIC_FLOAT_PRECISION> cur_pot = zeros_ND<3,PRISMATIC_FLOAT_PRECISION>({{radius.get_dimk(),radius.get_dimj(),radius.get_dimi()}});
+	for(auto z = 0; z < radius.get_dimk(); z++){
+        for(auto y = 0; y < radius.get_dimj(); y++ ){
+            for(auto x = 0; x < radius.get_dimi(); x++){
+				for(auto i = 0; i<6; i+=2){
+					cur_pot.at(z,y,x) += 2*pi*pi*a0*e*(factors.at(i)/radius.at(z,y,x))*exp(-2*pi*radius.at(z,y,x)*sqrt(factors.at(i+1)));
+				}
+				for(auto i = 6; i<12; i+=2){
+					cur_pot.at(z,y,x) += 2*pow(pi,5.0/2.0)*a0*e*factors.at(i)*pow(factors.at(i+1),-3.0/2.0)*exp(-pi*pi*radius.at(z,y,x)*radius.at(z,y,x)/factors.at(i+1));
+				}
+            }
+        }
+    }
+	return cur_pot;
+}
+
 } // namespace Prismatic

--- a/src/projectedPotential.cpp
+++ b/src/projectedPotential.cpp
@@ -196,9 +196,9 @@ Array2D<PRISMATIC_FLOAT_PRECISION> projPot(const size_t &Z,
 }
 
 Array3D<PRISMATIC_FLOAT_PRECISION> kirklandPotential3D(const size_t &Z, 
-										Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
-										Array1D<PRISMATIC_FLOAT_PRECISION> &yr,
-										Array1D<PRISMATIC_FLOAT_PRECISION> &zr)
+										const Array1D<PRISMATIC_FLOAT_PRECISION> &xr,
+										const Array1D<PRISMATIC_FLOAT_PRECISION> &yr,
+										const Array1D<PRISMATIC_FLOAT_PRECISION> &zr)
 {
 	static const PRISMATIC_FLOAT_PRECISION pi = std::acos(-1);
 	PRISMATIC_FLOAT_PRECISION a0 = 0.529; //bohr radius

--- a/unittests/include/potentialTests.h
+++ b/unittests/include/potentialTests.h
@@ -1,8 +1,4 @@
 #ifndef POTENTIAL_TESTS_H
 #define POTENTIAL_TESTS_H
 
-void test_case1();
-void test_case2();
-
-
 #endif

--- a/unittests/include/potentialTests.h
+++ b/unittests/include/potentialTests.h
@@ -1,0 +1,8 @@
+#ifndef POTENTIAL_TESTS_H
+#define POTENTIAL_TESTS_H
+
+void test_case1();
+void test_case2();
+
+
+#endif

--- a/unittests/potentialTests.cpp
+++ b/unittests/potentialTests.cpp
@@ -1,26 +1,64 @@
 #include "potentialTests.h"
-// #include "PRISM01_calcPotential.h"
+#include "PRISM01_calcPotential.h"
 #include <boost/test/unit_test.hpp>
-// #include "ArrayND.h"
+#include "ArrayND.h"
+#include <iostream>
 
+namespace Prismatic{
+    
 BOOST_AUTO_TEST_SUITE(potentialTests);
 
-BOOST_AUTO_TEST_CASE(test1){
-    BOOST_TEST(1==0);
-}
+BOOST_AUTO_TEST_CASE(kirklandPotential){
+    Array3D<PRISMATIC_FLOAT_PRECISION> radius = ones_ND<3,PRISMATIC_FLOAT_PRECISION>({{10,10,10}});
+    Array1D<PRISMATIC_FLOAT_PRECISION> factors = ones_ND<1, PRISMATIC_FLOAT_PRECISION>({{12}});
+    PRISMATIC_FLOAT_PRECISION tol = 0.000001;
+    PRISMATIC_FLOAT_PRECISION error_sum = 0;
+    //test first term
+    for(auto i = 6; i < 12; i+=2) factors.at(i) = 0;
+    Array3D<PRISMATIC_FLOAT_PRECISION> val = kirklandPotential3D(factors, radius);
+    PRISMATIC_FLOAT_PRECISION expected = 0.8423963; //all terms = 1 at radius 1
+    for(auto z = 0; z < radius.get_dimk(); z++){
+        for(auto y = 0; y < radius.get_dimj(); y++ ){
+            for(auto x = 0; x < radius.get_dimi(); x++){
+                error_sum += std::abs(val.at(z,y,x)-expected);
+            }
+        }
+    }
+    error_sum/=1000; //take mean
+    BOOST_TEST(error_sum<tol);
 
-// void test_case1(){
-//     // PRISMATIC_FLOAT_PRECISION radius = 1;
-//     // Prismatic::Array1D<PRISMATIC_FLOAT_PRECISION> factors({});
-//     // Array1D<PRISMATIC_FLOAT_PRECISION> factors;
-//     // PRISMATIC_FLOAT_PRECISION val = Prismatic::kirklandPotential3D(factors, radius);
-//     BOOST_TEST(1==0);
-// };
+    //test second term
+    for(auto i = 0; i < 12; i++) factors.at(i) = 1;
+    for(auto i = 0; i < 6; i++) factors.at(i) = 0;
+    val = kirklandPotential3D(factors, radius);
+    expected = 0.041355;
+    error_sum = 0.0;
+    for(auto z = 0; z < radius.get_dimk(); z++){
+        for(auto y = 0; y < radius.get_dimj(); y++ ){
+            for(auto x = 0; x < radius.get_dimi(); x++){
+                error_sum += std::abs(val.at(z,y,x)-expected);
+            }
+        }
+    }
+    error_sum/=1000; //take mean
+    BOOST_TEST(error_sum<tol);
 
-// void test_case2(){
-//     int a = 1;
-//     int b = 2;
-//     int c = a + b;
-// };
+    //test both
+    for(auto i = 0; i < 12; i++) factors.at(i) = 1;
+    val = kirklandPotential3D(factors, radius);
+    expected = 0.883751;
+    error_sum = 0.0;
+    for(auto z = 0; z < radius.get_dimk(); z++){
+        for(auto y = 0; y < radius.get_dimj(); y++ ){
+            for(auto x = 0; x < radius.get_dimi(); x++){
+                error_sum += std::abs(val.at(z,y,x)-expected);
+            }
+        }
+    }
+    error_sum/=1000; //take mean
+    BOOST_TEST(error_sum<tol);
+};
 
 BOOST_AUTO_TEST_SUITE_END();
+
+}

--- a/unittests/potentialTests.cpp
+++ b/unittests/potentialTests.cpp
@@ -1,5 +1,5 @@
 #include "potentialTests.h"
-#include "PRISM01_calcPotential.h"
+#include "projectedPotential.h"
 #include <boost/test/unit_test.hpp>
 #include "ArrayND.h"
 #include <iostream>

--- a/unittests/potentialTests.cpp
+++ b/unittests/potentialTests.cpp
@@ -1,0 +1,12 @@
+#include "potentialTests.h"
+#include <boost/test/unit_test.hpp>
+
+void test_case1(){
+    BOOST_TEST(1==0);
+};
+
+void test_case2(){
+    int a = 1;
+    int b = 2;
+    int c = a + b;
+};

--- a/unittests/potentialTests.cpp
+++ b/unittests/potentialTests.cpp
@@ -16,7 +16,105 @@ PRISMATIC_FLOAT_PRECISION a0 = 0.529; //bohr radius
 PRISMATIC_FLOAT_PRECISION e = 14.4; //electron charge in Volt-Angstoms
 PRISMATIC_FLOAT_PRECISION term1 =  2*pi*pi*a0*e;
 PRISMATIC_FLOAT_PRECISION term2 = 2*pow(pi,5.0/2.0)*a0*e;
-    
+
+class basicCell {
+
+    public:
+    basicCell()     {setupCell(),BOOST_TEST_MESSAGE( "Setting up fixture");}
+    ~basicCell()    {BOOST_TEST_MESSAGE( "Tearing down fixture");}
+    PRISMATIC_FLOAT_PRECISION cellDim = 20.0;
+    PRISMATIC_FLOAT_PRECISION potBound = 2.0;
+    PRISMATIC_FLOAT_PRECISION sliceThickness = 2.0;
+    PRISMATIC_FLOAT_PRECISION sliceThicknessFactor = 4;
+    PRISMATIC_FLOAT_PRECISION xPixel = 0.1;
+    PRISMATIC_FLOAT_PRECISION yPixel = 0.1;
+    PRISMATIC_FLOAT_PRECISION dzPot = sliceThickness/sliceThicknessFactor;
+    Array1D<size_t> imageSize = zeros_ND<1, size_t>({{2}});
+    std::vector<PRISMATIC_FLOAT_PRECISION> pixelSize;
+    PRISMATIC_FLOAT_PRECISION yleng;
+    PRISMATIC_FLOAT_PRECISION xleng;
+    PRISMATIC_FLOAT_PRECISION zleng;
+    Array1D<long> xvec;
+    Array1D<long> yvec;
+    Array1D<long> zvec;
+    Array1D<PRISMATIC_FLOAT_PRECISION> xr;
+    Array1D<PRISMATIC_FLOAT_PRECISION> yr;
+    Array1D<PRISMATIC_FLOAT_PRECISION> zr;
+    std::vector<atom> atoms;
+    atom new_atom;
+    std::vector<PRISMATIC_FLOAT_PRECISION> tiledCellDim;
+    Parameters<PRISMATIC_FLOAT_PRECISION> pars;
+
+    void setupCell()
+    {
+        imageSize[0] = (round(cellDim/(yPixel*16))*16);
+        imageSize[1] = (round(cellDim/(xPixel*16))*16);
+        pixelSize.push_back(cellDim/imageSize[0]);
+        pixelSize.push_back(cellDim/imageSize[1]);
+        pixelSize.push_back(dzPot);
+        yleng = std::ceil(potBound/pixelSize[0]);
+        xleng = std::ceil(potBound/pixelSize[1]);
+        zleng = std::ceil(potBound/dzPot);
+        xvec = zeros_ND<1,long>({{2*xleng+1}});
+        yvec = zeros_ND<1,long>({{2*yleng+1}});
+        zvec = zeros_ND<1,long>({{2*zleng+1}});
+        xr = zeros_ND<1,PRISMATIC_FLOAT_PRECISION>({{2*xleng+1}});
+        yr = zeros_ND<1,PRISMATIC_FLOAT_PRECISION>({{2*yleng+1}});
+        zr = zeros_ND<1,PRISMATIC_FLOAT_PRECISION>({{2*zleng+1}});
+
+        {
+            PRISMATIC_FLOAT_PRECISION tmpx = -xleng;
+            PRISMATIC_FLOAT_PRECISION tmpy = -yleng;
+            PRISMATIC_FLOAT_PRECISION tmpz = -zleng;
+            for (auto &i : xvec)
+                i = tmpx++;
+            for (auto &j : yvec)
+                j = tmpy++;
+            for (auto &k : zvec)
+                k = tmpz++;
+        }
+
+        for (auto i = 0; i < xr.size(); ++i) xr[i] = (PRISMATIC_FLOAT_PRECISION)xvec[i] * pixelSize[1];
+        for (auto j = 0; j < yr.size(); ++j) yr[j] = (PRISMATIC_FLOAT_PRECISION)yvec[j] * pixelSize[0];
+        for (auto j = 0; j < zr.size(); ++j) zr[j] = (PRISMATIC_FLOAT_PRECISION)zvec[j] * dzPot;
+
+        // create list of atoms
+        tiledCellDim.push_back(cellDim);
+        tiledCellDim.push_back(cellDim);
+        tiledCellDim.push_back(cellDim);
+        pars.tiledCellDim = tiledCellDim;
+
+        for(auto i = 0; i < 2; i++)
+        {
+            for(auto j = 0; j < 2; j++)
+            {
+                for(auto k = 0; k < 2; k++)
+                {
+                    new_atom.x = (1.0+2.0*i)/4.0;
+                    new_atom.y = (1.0+2.0*j)/4.0;
+                    new_atom.z = (1.0+2.0*k)/4.0;
+                    new_atom.sigma = 0.1;
+                    new_atom.species = 79;
+                    new_atom.occ = 1;
+                    atoms.push_back(new_atom);
+                }
+            }
+        }
+
+        // setting up parameter class
+        pars.meta.sliceThickness = sliceThickness;
+        pars.meta.zSampling = sliceThicknessFactor;
+        pars.meta.randomSeed = 11111;
+        pars.meta.numThreads = 8;
+        pars.atoms = atoms;
+        pars.pixelSize = pixelSize;
+        pars.imageSize = imageSize;
+        pars.dzPot = dzPot;
+    }
+};
+
+
+//misc helper functions
 PRISMATIC_FLOAT_PRECISION checkFaces(Array3D<PRISMATIC_FLOAT_PRECISION> &pot)
 {
     
@@ -139,6 +237,7 @@ void addMismatchedArray(Array3D<PRISMATIC_FLOAT_PRECISION> &big,
     }
 
 };
+
 
 BOOST_AUTO_TEST_SUITE(potentialTests);
 
@@ -313,53 +412,10 @@ BOOST_AUTO_TEST_CASE(potMin)
 };
 */
 
-BOOST_AUTO_TEST_CASE(projPotGeneration)
+
+BOOST_FIXTURE_TEST_CASE(projPotGeneration, basicCell)
 {
     PRISMATIC_FLOAT_PRECISION tol = 0.001;
-
-    PRISMATIC_FLOAT_PRECISION cellDim = 20.0;
-    PRISMATIC_FLOAT_PRECISION potBound = 2.0;
-    PRISMATIC_FLOAT_PRECISION sliceThickness = 2.0;
-    PRISMATIC_FLOAT_PRECISION sliceThicknessFactor = 4;
-    PRISMATIC_FLOAT_PRECISION xPixel = 0.1;
-    PRISMATIC_FLOAT_PRECISION yPixel = 0.1;
-    
-    Array1D<size_t> imageSize = zeros_ND<1, size_t>({{2}});
-    imageSize[0] = (round(cellDim/(yPixel*16))*16);
-    imageSize[1] = (round(cellDim/(xPixel*16))*16);
-    PRISMATIC_FLOAT_PRECISION dzPot = sliceThickness/sliceThicknessFactor;
-    std::vector<PRISMATIC_FLOAT_PRECISION> pixelSize;
-    pixelSize.push_back(cellDim/imageSize[0]);
-    pixelSize.push_back(cellDim/imageSize[1]);
-    pixelSize.push_back(dzPot);
-
-
-	PRISMATIC_FLOAT_PRECISION yleng = std::ceil(potBound/pixelSize[0]);
-	PRISMATIC_FLOAT_PRECISION xleng = std::ceil(potBound/pixelSize[1]);
-    PRISMATIC_FLOAT_PRECISION zleng = std::ceil(potBound/dzPot);
-
-	ArrayND<1, std::vector<long>> xvec(std::vector<long>(2 * (size_t)xleng + 1, 0), {{2 * (size_t)xleng + 1}});
-	ArrayND<1, std::vector<long>> yvec(std::vector<long>(2 * (size_t)yleng + 1, 0), {{2 * (size_t)yleng + 1}});
-	ArrayND<1, std::vector<long>> zvec(std::vector<long>(2 * (size_t)zleng + 1, 0), {{2 * (size_t)zleng + 1}});
-	{
-		PRISMATIC_FLOAT_PRECISION tmpx = -xleng;
-		PRISMATIC_FLOAT_PRECISION tmpy = -yleng;
-		PRISMATIC_FLOAT_PRECISION tmpz = -zleng;
-		for (auto &i : xvec)
-			i = tmpx++;
-		for (auto &j : yvec)
-			j = tmpy++;
-		for (auto &k : zvec)
-			k = tmpz++;
-	}
-
-    Array1D<PRISMATIC_FLOAT_PRECISION> xr(std::vector<PRISMATIC_FLOAT_PRECISION>(2 * (size_t)xleng + 1, 0), {{2 * (size_t)xleng + 1}});
-	Array1D<PRISMATIC_FLOAT_PRECISION> yr(std::vector<PRISMATIC_FLOAT_PRECISION>(2 * (size_t)yleng + 1, 0), {{2 * (size_t)yleng + 1}});
-	Array1D<PRISMATIC_FLOAT_PRECISION> zr(std::vector<PRISMATIC_FLOAT_PRECISION>(2 * (size_t)zleng + 1, 0), {{2 * (size_t)zleng + 1}});
-
-	for (auto i = 0; i < xr.size(); ++i) xr[i] = (PRISMATIC_FLOAT_PRECISION)xvec[i] * pixelSize[1];
-	for (auto j = 0; j < yr.size(); ++j) yr[j] = (PRISMATIC_FLOAT_PRECISION)yvec[j] * pixelSize[0];
-	for (auto j = 0; j < zr.size(); ++j) zr[j] = (PRISMATIC_FLOAT_PRECISION)zvec[j] * dzPot;
 
     //preparing reference potential for single atom potential
     const size_t Z = 79; //Gold!
@@ -382,54 +438,21 @@ BOOST_AUTO_TEST_CASE(projPotGeneration)
             }
         }
     }
-
-    // std::cout << xr.size() << std::endl;
-    // PRISMATIC_FLOAT_PRECISION testSum1 = 0.0;
-    // PRISMATIC_FLOAT_PRECISION testSum2 = 0.0;
-    // for (auto i = 0; i < refPot.size(); i++) testSum1 += refPot[i];
-    // for (auto i = 0; i < oneH.size(); i++) testSum2 += oneH[i];
-    // std::cout << testSum1 << " " << testSum2 << std::endl;
-
-
-    //generate reference 
-    Array3D<PRISMATIC_FLOAT_PRECISION> interpID;
-    PRISMATIC_FLOAT_PRECISION dx, dy, dz;
-    Parameters<PRISMATIC_FLOAT_PRECISION> pars;
-    pars.meta.sliceThickness = sliceThickness;
-    pars.meta.zSampling = sliceThicknessFactor;
-    //create list of atoms
-    std::vector<atom> atoms;
-    atom new_atom;
-    std::vector<PRISMATIC_FLOAT_PRECISION> tiledCellDim;
-    tiledCellDim.push_back(cellDim);
-    tiledCellDim.push_back(cellDim);
-    tiledCellDim.push_back(cellDim);
-    pars.tiledCellDim = tiledCellDim;
-
-    for(auto i = 0; i < 2; i++)
+    //expand dims to match lookup table
+    Array4D<PRISMATIC_FLOAT_PRECISION> oneH_table = zeros_ND<4, PRISMATIC_FLOAT_PRECISION>({{1,oneH.get_dimk(),oneH.get_dimj(),oneH.get_dimi()}});
+    for(auto k = 0; k < oneH.get_dimk(); k++)
     {
-        for(auto j = 0; j < 2; j++)
+        for(auto j = 0; j < oneH.get_dimj(); j++)
         {
-            for(auto k = 0; k < 2; k++)
+            for(auto i = 0; i < oneH.get_dimi(); i++)
             {
-                new_atom.x = (1.0+2.0*i)/4.0;
-                new_atom.y = (1.0+2.0*j)/4.0;
-                new_atom.z = (1.0+2.0*k)/4.0;
-                new_atom.sigma = 0.1;
-                new_atom.species = 1;
-                new_atom.occ = 1;
-                atoms.push_back(new_atom);
+                oneH_table.at(0,k,j,i) = oneH.at(k,j,i);
             }
         }
     }
-    
-    pars.atoms = atoms;
-    pars.meta.randomSeed = 11111;
-    pars.meta.numThreads = 8;
-    pars.pixelSize = pixelSize;
-    pars.imageSize = imageSize;
-    generateProjectedPotentials3D(pars, oneH, xvec, yvec, zvec); //H is the only lookup
-    //for dx=dy=dz=0, all faces should be zero on potShift equivalent
+
+	std::vector<size_t> unique_species = get_unique_atomic_species(pars);
+    generateProjectedPotentials3D(pars, oneH_table, unique_species, xvec, yvec, zvec); //H is the only lookup
     Array3D<PRISMATIC_FLOAT_PRECISION> testPot = pars.pot;
     PRISMATIC_FLOAT_PRECISION refPotSum = 0;
     PRISMATIC_FLOAT_PRECISION testPotSum = 0;
@@ -438,22 +461,68 @@ BOOST_AUTO_TEST_CASE(projPotGeneration)
     for(auto i = 0; i < oneH.size(); i++) refPotSum2 += 8*oneH[i];
     for(auto i = 0; i < testPot.size(); i++) testPotSum += testPot[i];
 
-    std::cout << "\% error (test vs ref): " << 100*std::abs(refPotSum-testPotSum)/refPotSum << std::endl;
-    std::cout << "\% error (test vs ref2): " << 100*std::abs(refPotSum2-testPotSum)/refPotSum2 << std::endl;
-    std::cout << "\% error (ref vs ref2): " << 100*std::abs(refPotSum-refPotSum2)/refPotSum2 << std::endl;
+    // std::cout << "\% error (test vs ref): " << 100*std::abs(refPotSum-testPotSum)/refPotSum << std::endl;
+    // std::cout << "\% error (test vs ref2): " << 100*std::abs(refPotSum2-testPotSum)/refPotSum2 << std::endl;
+    // std::cout << "\% error (ref vs ref2): " << 100*std::abs(refPotSum-refPotSum2)/refPotSum2 << std::endl;
     BOOST_TEST(std::abs(refPotSum-testPotSum)/refPotSum<tol);
     BOOST_TEST(std::abs(refPotSum2-testPotSum)/refPotSum2<tol);
 
     //print min val in testPot
     PRISMATIC_FLOAT_PRECISION minVal = pow(2,10); //check for nonnegativity
     for(auto i = 0; i < testPot.size(); i++) minVal = (testPot[i] < minVal) ? testPot[i] : minVal;
-    std::cout << "minVal: " << minVal << std::endl;
+    // std::cout << "minVal: " << minVal << std::endl;
     BOOST_TEST(minVal >=0);
     
-    testPot.toMRC_f("testPot.mrc");
-    refPot.toMRC_f("refPot.mrc");
+    // testPot.toMRC_f("testPot.mrc");
+    // refPot.toMRC_f("refPot.mrc");
 };
 
+BOOST_FIXTURE_TEST_CASE(PRISM01_integration, basicCell)
+{
+    PRISMATIC_FLOAT_PRECISION tol = 0.001;
+    //preparing reference potential for single atom potential
+    const size_t Z = 79; //Gold!
+    Array3D<PRISMATIC_FLOAT_PRECISION> refPot = zeros_ND<3,PRISMATIC_FLOAT_PRECISION>({{zr.size()*2,yr.size()*2,xr.size()*2}});
+    Array3D<PRISMATIC_FLOAT_PRECISION> oneH = kirklandPotential3D(Z, xr, yr, zr);
+    //loop through quadrants
+    size_t offset_x;
+    size_t offset_y;
+    size_t offset_z;
+    for(auto k = 0; k < 2; k++)
+    {
+        for(auto j = 0; j < 2; j++)
+        {
+            for(auto i = 0; i < 2; i++)
+            {
+                offset_x = i*oneH.get_dimi();
+                offset_y = j*oneH.get_dimj();
+                offset_z = k*oneH.get_dimk();
+                addMismatchedArray(refPot, oneH, offset_x, offset_y, offset_z);
+            }
+        }
+    }
+
+    pars.meta.potential3D = true;
+    pars.meta.numThreads = 1;
+    PRISM01_calcPotential(pars);
+    Array3D<PRISMATIC_FLOAT_PRECISION> testPot = pars.pot;
+
+    PRISMATIC_FLOAT_PRECISION refPotSum = 0;
+    PRISMATIC_FLOAT_PRECISION testPotSum = 0;
+    PRISMATIC_FLOAT_PRECISION refPotSum2 = 0;
+    for(auto i = 0; i < refPot.size(); i++) refPotSum += refPot[i];
+    for(auto i = 0; i < oneH.size(); i++) refPotSum2 += 8*oneH[i];
+    for(auto i = 0; i < testPot.size(); i++) testPotSum += testPot[i];
+
+    BOOST_TEST(std::abs(refPotSum-testPotSum)/refPotSum<tol);
+    BOOST_TEST(std::abs(refPotSum2-testPotSum)/refPotSum2<tol);
+
+    //print min val in testPot
+    PRISMATIC_FLOAT_PRECISION minVal = pow(2,10); //check for nonnegativity
+    for(auto i = 0; i < testPot.size(); i++) minVal = (testPot[i] < minVal) ? testPot[i] : minVal;
+    // std::cout << "minVal: " << minVal << std::endl;
+    BOOST_TEST(minVal >=0);
+};
 
 BOOST_AUTO_TEST_SUITE_END();
 

--- a/unittests/potentialTests.cpp
+++ b/unittests/potentialTests.cpp
@@ -4,18 +4,65 @@
 #include "ArrayND.h"
 #include <iostream>
 #include "kirkland_params.h"
+#include <vector>
 
 namespace Prismatic{
 
-    static const PRISMATIC_FLOAT_PRECISION pi = std::acos(-1);
-	PRISMATIC_FLOAT_PRECISION a0 = 0.529; //bohr radius
-	PRISMATIC_FLOAT_PRECISION e = 14.4; //electron charge in Volt-Angstoms
-	PRISMATIC_FLOAT_PRECISION term1 =  2*pi*pi*a0*e;
-	PRISMATIC_FLOAT_PRECISION term2 = 2*pow(pi,5.0/2.0)*a0*e;
+static const PRISMATIC_FLOAT_PRECISION pi = std::acos(-1);
+PRISMATIC_FLOAT_PRECISION a0 = 0.529; //bohr radius
+PRISMATIC_FLOAT_PRECISION e = 14.4; //electron charge in Volt-Angstoms
+PRISMATIC_FLOAT_PRECISION term1 =  2*pi*pi*a0*e;
+PRISMATIC_FLOAT_PRECISION term2 = 2*pow(pi,5.0/2.0)*a0*e;
     
+PRISMATIC_FLOAT_PRECISION checkFaces(Array3D<PRISMATIC_FLOAT_PRECISION> &pot)
+{
+    
+    size_t xFace[] = {0, pot.get_dimi()-1};
+    size_t yFace[] = {0, pot.get_dimj()-1};
+    size_t zFace[] = {0, pot.get_dimk()-1};
+    PRISMATIC_FLOAT_PRECISION errSum = 0;
+    //+-x
+    for(auto i = 0; i < 2; i++)
+    {
+        for(auto j = 0; j < pot.get_dimj(); j++)
+        {
+            for(auto k = 0; k < pot.get_dimk(); k++)
+            {
+                errSum += pot.at(k,j,xFace[i]);
+            }
+        }
+    }
+
+    //+-y
+    for(auto j = 0; j < 2; j++)
+    {
+        for(auto i = 0; i < pot.get_dimi(); i++)
+        {
+            for(auto k = 0; k < pot.get_dimk(); k++)
+            {
+                errSum += pot.at(k,yFace[j],i);
+            }
+        }
+    }
+
+    //+-z
+    for(auto k = 0; k < 2; k++)
+    {
+        for(auto i = 0; i < pot.get_dimi(); i++)
+        {
+            for(auto j = 0; j < pot.get_dimj(); j++)
+            {
+                errSum += pot.at(zFace[k],j,i);
+            }
+        }
+    }
+    return errSum;
+};
+
 BOOST_AUTO_TEST_SUITE(potentialTests);
 
-BOOST_AUTO_TEST_CASE(potential3D){
+BOOST_AUTO_TEST_CASE(pot3D_function_test)
+{
     Array3D<PRISMATIC_FLOAT_PRECISION> radius = ones_ND<3,PRISMATIC_FLOAT_PRECISION>({{10,10,10}});
     Array1D<PRISMATIC_FLOAT_PRECISION> xr = ones_ND<1,PRISMATIC_FLOAT_PRECISION>({{10}});
     Array1D<PRISMATIC_FLOAT_PRECISION> yr = ones_ND<1,PRISMATIC_FLOAT_PRECISION>({{10}});
@@ -26,30 +73,161 @@ BOOST_AUTO_TEST_CASE(potential3D){
     yr /= sqrt(3);
     zr /= sqrt(3);
     
+    //seed corner with lower radius so that we can test function with potMin taken into acct
+    xr.at(0) = 0.5;
+    yr.at(0) = 0.5;
+    zr.at(0) = 0.5;
+
+    PRISMATIC_FLOAT_PRECISION r2 = pow(xr.at(0),2) + pow(yr.at(0),2) + pow(zr.at(0),2);
+    PRISMATIC_FLOAT_PRECISION r = sqrt(r2);
+    
     const size_t Z = 1;
     std::vector<PRISMATIC_FLOAT_PRECISION> parameters;
     parameters.resize(NUM_PARAMETERS);
     for (auto i =0; i < NUM_PARAMETERS; i++) parameters[i] = fparams[(Z-1)*NUM_PARAMETERS + i];
     
-    PRISMATIC_FLOAT_PRECISION expected = term1*(parameters[0]*exp(-2*pi*sqrt(parameters[1]))
+    PRISMATIC_FLOAT_PRECISION pot_at_1 = term1*(parameters[0]*exp(-2*pi*sqrt(parameters[1]))
                                         + parameters[2]*exp(-2*pi*sqrt(parameters[3]))
                                         + parameters[4]*exp(-2*pi*sqrt(parameters[5])))
                                 + term2*(parameters[6]*pow(parameters[7],-3.0/2.0)*exp(-pi*pi/parameters[7])
                                         + parameters[8]*pow(parameters[9],-3.0/2.0)*exp(-pi*pi/parameters[9])
-                                        + parameters[10]*pow(parameters[11],-3.0/2.0)*exp(-pi*pi/parameters[11])); 
+                                        + parameters[10]*pow(parameters[11],-3.0/2.0)*exp(-pi*pi/parameters[11]));
+
+    PRISMATIC_FLOAT_PRECISION pot_at_0 = term1*(parameters[0]*exp(-2*pi*r*sqrt(parameters[1]))/r
+                                        + parameters[2]*exp(-2*pi*r*sqrt(parameters[3]))/r
+                                        + parameters[4]*exp(-2*pi*r*sqrt(parameters[5]))/r)
+                                + term2*(parameters[6]*pow(parameters[7],-3.0/2.0)*exp(-pi*pi*r2/parameters[7])
+                                        + parameters[8]*pow(parameters[9],-3.0/2.0)*exp(-pi*pi*r2/parameters[9])
+                                        + parameters[10]*pow(parameters[11],-3.0/2.0)*exp(-pi*pi*r2/parameters[11]));
+
+    PRISMATIC_FLOAT_PRECISION expected = pot_at_0 - pot_at_1; //since potMin only checks 3 points
   
     Array3D<PRISMATIC_FLOAT_PRECISION> pot = kirklandPotential3D(Z, xr, yr, zr);
-    PRISMATIC_FLOAT_PRECISION tol = 0.000001;
-    PRISMATIC_FLOAT_PRECISION error_sum = 0;
-    for(auto z = 0; z < radius.get_dimk(); z++){
-        for(auto y = 0; y < radius.get_dimj(); y++ ){
-            for(auto x = 0; x < radius.get_dimi(); x++){
-                error_sum += std::abs(pot.at(z,y,x)-expected);
-            }
-        }
-    }
-    error_sum/=1000; //take mean
-    BOOST_TEST(error_sum<tol);
+    PRISMATIC_FLOAT_PRECISION tol = 0.01;
+    PRISMATIC_FLOAT_PRECISION error = std::abs(pot.at(0,0,0) - expected);
+
+    BOOST_TEST(error<tol);
+};
+
+BOOST_AUTO_TEST_CASE(potMin)
+{
+    //after potMin correction, potential should be non-negative with all faces of 3D potential prism = 0; 
+    //test cubic
+    PRISMATIC_FLOAT_PRECISION yleng = 20;
+	PRISMATIC_FLOAT_PRECISION xleng = 20;
+    PRISMATIC_FLOAT_PRECISION zleng = 20;
+
+	ArrayND<1, std::vector<long>> xvec(std::vector<long>(2 * (size_t)xleng + 1, 0), {{2 * (size_t)xleng + 1}});
+	ArrayND<1, std::vector<long>> yvec(std::vector<long>(2 * (size_t)yleng + 1, 0), {{2 * (size_t)yleng + 1}});
+	ArrayND<1, std::vector<long>> zvec(std::vector<long>(2 * (size_t)zleng + 1, 0), {{2 * (size_t)zleng + 1}});
+	{
+		PRISMATIC_FLOAT_PRECISION tmpx = -xleng;
+		PRISMATIC_FLOAT_PRECISION tmpy = -yleng;
+		PRISMATIC_FLOAT_PRECISION tmpz = -zleng;
+		for (auto &i : xvec)
+			i = tmpx++;
+		for (auto &j : yvec)
+			j = tmpy++;
+		for (auto &k : zvec)
+			k = tmpz++;
+	}
+
+    PRISMATIC_FLOAT_PRECISION xPixel = 0.1;
+    PRISMATIC_FLOAT_PRECISION yPixel = 0.1;
+    PRISMATIC_FLOAT_PRECISION zPixel = 0.1;
+
+    Array1D<PRISMATIC_FLOAT_PRECISION> xr(std::vector<PRISMATIC_FLOAT_PRECISION>(2 * (size_t)xleng + 1, 0), {{2 * (size_t)xleng + 1}});
+	Array1D<PRISMATIC_FLOAT_PRECISION> yr(std::vector<PRISMATIC_FLOAT_PRECISION>(2 * (size_t)yleng + 1, 0), {{2 * (size_t)yleng + 1}});
+	Array1D<PRISMATIC_FLOAT_PRECISION> zr(std::vector<PRISMATIC_FLOAT_PRECISION>(2 * (size_t)zleng + 1, 0), {{2 * (size_t)zleng + 1}});
+
+	for (auto i = 0; i < xr.size(); ++i) xr[i] = (PRISMATIC_FLOAT_PRECISION)xvec[i] * xPixel;
+	for (auto j = 0; j < yr.size(); ++j) yr[j] = (PRISMATIC_FLOAT_PRECISION)yvec[j] * yPixel;
+	for (auto j = 0; j < zr.size(); ++j) zr[j] = (PRISMATIC_FLOAT_PRECISION)zvec[j] * zPixel;
+
+    const size_t Z = 1; //Hydrogen!
+    Array3D<PRISMATIC_FLOAT_PRECISION> pot = kirklandPotential3D(Z, xr, yr, zr);
+
+    PRISMATIC_FLOAT_PRECISION tol = 0.0001;
+    //test faces
+    PRISMATIC_FLOAT_PRECISION errSum = checkFaces(pot);
+    PRISMATIC_FLOAT_PRECISION minVal = pow(2,10); //check for nonnegativity
+    for(auto i = 0; i < pot.size(); i++) minVal = (pot[i] < minVal) ? pot[i] : minVal;
+    BOOST_TEST(errSum < tol);
+    BOOST_TEST(minVal >= 0);
+
+    //test rectangular in 1 direction
+    xPixel = 0.05;
+    for (auto i = 0; i < xr.size(); ++i) xr[i] = (PRISMATIC_FLOAT_PRECISION)xvec[i] * xPixel;
+	for (auto j = 0; j < yr.size(); ++j) yr[j] = (PRISMATIC_FLOAT_PRECISION)yvec[j] * yPixel;
+	for (auto j = 0; j < zr.size(); ++j) zr[j] = (PRISMATIC_FLOAT_PRECISION)zvec[j] * zPixel;
+    pot = kirklandPotential3D(Z, xr, yr, zr);
+    errSum = checkFaces(pot);
+    minVal = pow(2,10);
+    for(auto i = 0; i < pot.size(); i++) minVal = (pot[i] < minVal) ? pot[i] : minVal;
+    BOOST_TEST(errSum < tol);
+    BOOST_TEST(minVal >= 0);
+
+    xPixel = 0.1;
+    yPixel = 0.05;
+	for (auto i = 0; i < xr.size(); ++i) xr[i] = (PRISMATIC_FLOAT_PRECISION)xvec[i] * xPixel;
+	for (auto j = 0; j < yr.size(); ++j) yr[j] = (PRISMATIC_FLOAT_PRECISION)yvec[j] * yPixel;
+	for (auto j = 0; j < zr.size(); ++j) zr[j] = (PRISMATIC_FLOAT_PRECISION)zvec[j] * zPixel;
+    pot = kirklandPotential3D(Z, xr, yr, zr);
+    errSum = checkFaces(pot);
+    minVal = pow(2,10);
+    for(auto i = 0; i < pot.size(); i++) minVal = (pot[i] < minVal) ? pot[i] : minVal;
+    BOOST_TEST(errSum < tol);
+    BOOST_TEST(minVal >= 0);
+
+    yPixel = 0.1;
+    zPixel = 0.05;
+	for (auto i = 0; i < xr.size(); ++i) xr[i] = (PRISMATIC_FLOAT_PRECISION)xvec[i] * xPixel;
+	for (auto j = 0; j < yr.size(); ++j) yr[j] = (PRISMATIC_FLOAT_PRECISION)yvec[j] * yPixel;
+	for (auto j = 0; j < zr.size(); ++j) zr[j] = (PRISMATIC_FLOAT_PRECISION)zvec[j] * zPixel;
+    pot = kirklandPotential3D(Z, xr, yr, zr);
+    errSum = checkFaces(pot);
+    minVal = pow(2,10);
+    for(auto i = 0; i < pot.size(); i++) minVal = (pot[i] < minVal) ? pot[i] : minVal;
+    BOOST_TEST(errSum < tol);
+    BOOST_TEST(minVal >= 0);
+
+    //test rectangulars in 2 directions
+    xPixel = 0.05;
+    yPixel = 0.05;
+    zPixel = 0.1;
+	for (auto i = 0; i < xr.size(); ++i) xr[i] = (PRISMATIC_FLOAT_PRECISION)xvec[i] * xPixel;
+	for (auto j = 0; j < yr.size(); ++j) yr[j] = (PRISMATIC_FLOAT_PRECISION)yvec[j] * yPixel;
+	for (auto j = 0; j < zr.size(); ++j) zr[j] = (PRISMATIC_FLOAT_PRECISION)zvec[j] * zPixel;
+    pot = kirklandPotential3D(Z, xr, yr, zr);
+    errSum = checkFaces(pot);
+    minVal = pow(2,10);
+    for(auto i = 0; i < pot.size(); i++) minVal = (pot[i] < minVal) ? pot[i] : minVal;
+    BOOST_TEST(errSum < tol);
+    BOOST_TEST(minVal >= 0);
+
+    xPixel = 0.1;
+    zPixel = 0.05;
+	for (auto i = 0; i < xr.size(); ++i) xr[i] = (PRISMATIC_FLOAT_PRECISION)xvec[i] * xPixel;
+	for (auto j = 0; j < yr.size(); ++j) yr[j] = (PRISMATIC_FLOAT_PRECISION)yvec[j] * yPixel;
+	for (auto j = 0; j < zr.size(); ++j) zr[j] = (PRISMATIC_FLOAT_PRECISION)zvec[j] * zPixel;
+    pot = kirklandPotential3D(Z, xr, yr, zr);
+    errSum = checkFaces(pot);
+    minVal = pow(2,10);
+    for(auto i = 0; i < pot.size(); i++) minVal = (pot[i] < minVal) ? pot[i] : minVal;
+    BOOST_TEST(errSum < tol);
+    BOOST_TEST(minVal >= 0);
+
+    yPixel = 0.1;
+    xPixel = 0.05;
+	for (auto i = 0; i < xr.size(); ++i) xr[i] = (PRISMATIC_FLOAT_PRECISION)xvec[i] * xPixel;
+	for (auto j = 0; j < yr.size(); ++j) yr[j] = (PRISMATIC_FLOAT_PRECISION)yvec[j] * yPixel;
+	for (auto j = 0; j < zr.size(); ++j) zr[j] = (PRISMATIC_FLOAT_PRECISION)zvec[j] * zPixel;
+    pot = kirklandPotential3D(Z, xr, yr, zr);
+    errSum = checkFaces(pot);
+    minVal = pow(2,10);
+    for(auto i = 0; i < pot.size(); i++) minVal = (pot[i] < minVal) ? pot[i] : minVal;
+    BOOST_TEST(errSum < tol);
+    BOOST_TEST(minVal >= 0);
 };
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/unittests/potentialTests.cpp
+++ b/unittests/potentialTests.cpp
@@ -3,55 +3,48 @@
 #include <boost/test/unit_test.hpp>
 #include "ArrayND.h"
 #include <iostream>
+#include "kirkland_params.h"
 
 namespace Prismatic{
+
+    static const PRISMATIC_FLOAT_PRECISION pi = std::acos(-1);
+	PRISMATIC_FLOAT_PRECISION a0 = 0.529; //bohr radius
+	PRISMATIC_FLOAT_PRECISION e = 14.4; //electron charge in Volt-Angstoms
+	PRISMATIC_FLOAT_PRECISION term1 =  2*pi*pi*a0*e;
+	PRISMATIC_FLOAT_PRECISION term2 = 2*pow(pi,5.0/2.0)*a0*e;
     
 BOOST_AUTO_TEST_SUITE(potentialTests);
 
-BOOST_AUTO_TEST_CASE(kirklandPotential){
+BOOST_AUTO_TEST_CASE(potential3D){
     Array3D<PRISMATIC_FLOAT_PRECISION> radius = ones_ND<3,PRISMATIC_FLOAT_PRECISION>({{10,10,10}});
-    Array1D<PRISMATIC_FLOAT_PRECISION> factors = ones_ND<1, PRISMATIC_FLOAT_PRECISION>({{12}});
+    Array1D<PRISMATIC_FLOAT_PRECISION> xr = ones_ND<1,PRISMATIC_FLOAT_PRECISION>({{10}});
+    Array1D<PRISMATIC_FLOAT_PRECISION> yr = ones_ND<1,PRISMATIC_FLOAT_PRECISION>({{10}});
+    Array1D<PRISMATIC_FLOAT_PRECISION> zr = ones_ND<1,PRISMATIC_FLOAT_PRECISION>({{10}});
+
+    //normalize radius to 1 at all points in grid
+    xr /= sqrt(3);
+    yr /= sqrt(3);
+    zr /= sqrt(3);
+    
+    const size_t Z = 1;
+    std::vector<PRISMATIC_FLOAT_PRECISION> parameters;
+    parameters.resize(NUM_PARAMETERS);
+    for (auto i =0; i < NUM_PARAMETERS; i++) parameters[i] = fparams[(Z-1)*NUM_PARAMETERS + i];
+    
+    PRISMATIC_FLOAT_PRECISION expected = term1*(parameters[0]*exp(-2*pi*sqrt(parameters[1]))
+                                        + parameters[2]*exp(-2*pi*sqrt(parameters[3]))
+                                        + parameters[4]*exp(-2*pi*sqrt(parameters[5])))
+                                + term2*(parameters[6]*pow(parameters[7],-3.0/2.0)*exp(-pi*pi/parameters[7])
+                                        + parameters[8]*pow(parameters[9],-3.0/2.0)*exp(-pi*pi/parameters[9])
+                                        + parameters[10]*pow(parameters[11],-3.0/2.0)*exp(-pi*pi/parameters[11])); 
+  
+    Array3D<PRISMATIC_FLOAT_PRECISION> pot = kirklandPotential3D(Z, xr, yr, zr);
     PRISMATIC_FLOAT_PRECISION tol = 0.000001;
     PRISMATIC_FLOAT_PRECISION error_sum = 0;
-    //test first term
-    for(auto i = 6; i < 12; i+=2) factors.at(i) = 0;
-    Array3D<PRISMATIC_FLOAT_PRECISION> val = kirklandPotential3D(factors, radius);
-    PRISMATIC_FLOAT_PRECISION expected = 0.8423963; //all terms = 1 at radius 1
     for(auto z = 0; z < radius.get_dimk(); z++){
         for(auto y = 0; y < radius.get_dimj(); y++ ){
             for(auto x = 0; x < radius.get_dimi(); x++){
-                error_sum += std::abs(val.at(z,y,x)-expected);
-            }
-        }
-    }
-    error_sum/=1000; //take mean
-    BOOST_TEST(error_sum<tol);
-
-    //test second term
-    for(auto i = 0; i < 12; i++) factors.at(i) = 1;
-    for(auto i = 0; i < 6; i++) factors.at(i) = 0;
-    val = kirklandPotential3D(factors, radius);
-    expected = 0.041355;
-    error_sum = 0.0;
-    for(auto z = 0; z < radius.get_dimk(); z++){
-        for(auto y = 0; y < radius.get_dimj(); y++ ){
-            for(auto x = 0; x < radius.get_dimi(); x++){
-                error_sum += std::abs(val.at(z,y,x)-expected);
-            }
-        }
-    }
-    error_sum/=1000; //take mean
-    BOOST_TEST(error_sum<tol);
-
-    //test both
-    for(auto i = 0; i < 12; i++) factors.at(i) = 1;
-    val = kirklandPotential3D(factors, radius);
-    expected = 0.883751;
-    error_sum = 0.0;
-    for(auto z = 0; z < radius.get_dimk(); z++){
-        for(auto y = 0; y < radius.get_dimj(); y++ ){
-            for(auto x = 0; x < radius.get_dimi(); x++){
-                error_sum += std::abs(val.at(z,y,x)-expected);
+                error_sum += std::abs(pot.at(z,y,x)-expected);
             }
         }
     }

--- a/unittests/potentialTests.cpp
+++ b/unittests/potentialTests.cpp
@@ -1,12 +1,26 @@
 #include "potentialTests.h"
+// #include "PRISM01_calcPotential.h"
 #include <boost/test/unit_test.hpp>
+// #include "ArrayND.h"
 
-void test_case1(){
+BOOST_AUTO_TEST_SUITE(potentialTests);
+
+BOOST_AUTO_TEST_CASE(test1){
     BOOST_TEST(1==0);
-};
+}
 
-void test_case2(){
-    int a = 1;
-    int b = 2;
-    int c = a + b;
-};
+// void test_case1(){
+//     // PRISMATIC_FLOAT_PRECISION radius = 1;
+//     // Prismatic::Array1D<PRISMATIC_FLOAT_PRECISION> factors({});
+//     // Array1D<PRISMATIC_FLOAT_PRECISION> factors;
+//     // PRISMATIC_FLOAT_PRECISION val = Prismatic::kirklandPotential3D(factors, radius);
+//     BOOST_TEST(1==0);
+// };
+
+// void test_case2(){
+//     int a = 1;
+//     int b = 2;
+//     int c = a + b;
+// };
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/unittests/potentialTests.cpp
+++ b/unittests/potentialTests.cpp
@@ -415,8 +415,9 @@ BOOST_AUTO_TEST_CASE(projPotGeneration)
                 new_atom.x = (1.0+2.0*i)/4.0;
                 new_atom.y = (1.0+2.0*j)/4.0;
                 new_atom.z = (1.0+2.0*k)/4.0;
-                new_atom.sigma = 0.0800;
+                new_atom.sigma = 0.1;
                 new_atom.species = 1;
+                new_atom.occ = 1;
                 atoms.push_back(new_atom);
             }
         }
@@ -424,6 +425,7 @@ BOOST_AUTO_TEST_CASE(projPotGeneration)
     
     pars.atoms = atoms;
     pars.meta.randomSeed = 11111;
+    pars.meta.numThreads = 8;
     pars.pixelSize = pixelSize;
     pars.imageSize = imageSize;
     generateProjectedPotentials3D(pars, oneH, xvec, yvec, zvec); //H is the only lookup
@@ -436,15 +438,20 @@ BOOST_AUTO_TEST_CASE(projPotGeneration)
     for(auto i = 0; i < oneH.size(); i++) refPotSum2 += 8*oneH[i];
     for(auto i = 0; i < testPot.size(); i++) testPotSum += testPot[i];
 
-    std::cout << "refPot dims: " << refPot.get_dimi() << " " << refPot.get_dimj() << " " << refPot.get_dimk() << std::endl;
-    std::cout << "testPot dims: " << testPot.get_dimi() << " " << testPot.get_dimj() << " " << testPot.get_dimk() << std::endl;
-
     std::cout << "\% error (test vs ref): " << 100*std::abs(refPotSum-testPotSum)/refPotSum << std::endl;
     std::cout << "\% error (test vs ref2): " << 100*std::abs(refPotSum2-testPotSum)/refPotSum2 << std::endl;
     std::cout << "\% error (ref vs ref2): " << 100*std::abs(refPotSum-refPotSum2)/refPotSum2 << std::endl;
     BOOST_TEST(std::abs(refPotSum-testPotSum)/refPotSum<tol);
     BOOST_TEST(std::abs(refPotSum2-testPotSum)/refPotSum2<tol);
 
+    //print min val in testPot
+    PRISMATIC_FLOAT_PRECISION minVal = pow(2,10); //check for nonnegativity
+    for(auto i = 0; i < testPot.size(); i++) minVal = (testPot[i] < minVal) ? testPot[i] : minVal;
+    std::cout << "minVal: " << minVal << std::endl;
+    BOOST_TEST(minVal >=0);
+    
+    testPot.toMRC_f("testPot.mrc");
+    refPot.toMRC_f("refPot.mrc");
 };
 
 

--- a/unittests/testSuite.cpp
+++ b/unittests/testSuite.cpp
@@ -1,22 +1,4 @@
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_MODULE PrismaticTestSuite
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 #include "potentialTests.h"
-
-namespace bt = boost::unit_test;
-
-bt::test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
-{
-    bt::framework::master_test_suite().p_name.value = "Prismatic Test Suite";
-
-    bt::test_suite* ts1 = BOOST_TEST_SUITE( "potentialTests" );
-    ts1->add( BOOST_TEST_CASE( &test_case1 ) );
-    ts1->add( BOOST_TEST_CASE( &test_case2 ) );
-
-    // bt::test_suite* ts2 = BOOST_TEST_SUITE( "test_suite2" );
-    // ts2->add( BOOST_TEST_CASE( &test_case3 ) );
-    // ts2->add( BOOST_TEST_CASE( &test_case4 ) );
-
-    bt::framework::master_test_suite().add( ts1 );
-    // bt::framework::master_test_suite().add( ts2 );
-
-    return 0;
-}

--- a/unittests/testSuite.cpp
+++ b/unittests/testSuite.cpp
@@ -1,9 +1,22 @@
-#define BOOST_TEST_MAIN
 #include <boost/test/included/unit_test.hpp>
+#include "potentialTests.h"
 
 namespace bt = boost::unit_test;
 
-BOOST_AUTO_TEST_CASE( filler )
+bt::test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 {
-    BOOST_TEST( 1== 1);
+    bt::framework::master_test_suite().p_name.value = "Prismatic Test Suite";
+
+    bt::test_suite* ts1 = BOOST_TEST_SUITE( "potentialTests" );
+    ts1->add( BOOST_TEST_CASE( &test_case1 ) );
+    ts1->add( BOOST_TEST_CASE( &test_case2 ) );
+
+    // bt::test_suite* ts2 = BOOST_TEST_SUITE( "test_suite2" );
+    // ts2->add( BOOST_TEST_CASE( &test_case3 ) );
+    // ts2->add( BOOST_TEST_CASE( &test_case4 ) );
+
+    bt::framework::master_test_suite().add( ts1 );
+    // bt::framework::master_test_suite().add( ts2 );
+
+    return 0;
 }


### PR DESCRIPTION
Adds unit tests, function calls, and parsing options for using 3D parameterization for potential generation.

3D potential option is called with --3Dpotential 1/0 or -3DP 1/0 on the command line

Unit testing can be built with -DPRISMATIC_TESTS=1 when configuring CMake
tests will run automatically on build, and can be run again with ./prismatic-tests --log_level=all

GUI features not updated
boost test library needs to be compiled to be able to compile and use prismatic-tests

